### PR TITLE
Switched width & height around in commands comment

### DIFF
--- a/src/placeholdit.coffee
+++ b/src/placeholdit.coffee
@@ -8,7 +8,7 @@
 #   None
 #
 # Commands:
-#   placeholder height width
+#   placeholder width height
 #
 # Author:
 #   janhenckens


### PR DESCRIPTION
I noticed this is swapped, I assume it's a typo. 